### PR TITLE
feat: make duoke nav timeout configurable

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -7,6 +7,7 @@ load_dotenv()
 class Settings(BaseModel):
     gemini_api_key: str = os.getenv("GEMINI_API_KEY", "")
     douke_url: str = os.getenv("DOUKE_URL", "https://web.duoke.com/?lang=en#/dk/main/chat")
+    nav_timeout_ms: int = int(os.getenv("NAV_TIMEOUT_MS", "60000"))
     max_conversations: int = int(os.getenv("MAX_CONVERSATIONS", "50"))
     history_depth: int = int(os.getenv("HISTORY_DEPTH", "8"))
     apply_needs_reply_filter: bool = os.getenv("APPLY_NEEDS_REPLY_FILTER", "nao").lower() in ("sim","yes","true","1")

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -170,11 +170,16 @@ class DuokeBot:
         tenta detectar 2FA. Se 2FA for solicitado, deixa self.awaiting_2fa=True
         e retorna (sem levantar exceção) — a UI deve chamar provide_2fa_code().
         """
-        await page.goto(settings.douke_url, wait_until="domcontentloaded")
+        nav_timeout = getattr(settings, "nav_timeout_ms", 60000)
+        await page.goto(
+            settings.douke_url,
+            wait_until="domcontentloaded",
+            timeout=nav_timeout,
+        )
 
         # Aguarda rede “assentar”
         try:
-            await page.wait_for_load_state("networkidle", timeout=30000)
+            await page.wait_for_load_state("networkidle", timeout=nav_timeout)
         except Exception:
             pass
 
@@ -223,7 +228,7 @@ class DuokeBot:
 
         # Espera algo acontecer
         try:
-            await page.wait_for_load_state("networkidle", timeout=15000)
+            await page.wait_for_load_state("networkidle", timeout=nav_timeout)
         except Exception:
             pass
 
@@ -244,12 +249,12 @@ class DuokeBot:
             if chat_list_container:
                 await page.wait_for_selector(
                     f"{chat_list_container}, {chat_list_item}, ul.message_main",
-                    timeout=60000,
+                    timeout=nav_timeout,
                 )
             else:
                 await page.wait_for_selector(
                     f"{chat_list_item}, ul.message_main",
-                    timeout=60000,
+                    timeout=nav_timeout,
                 )
         except Exception:
             # não quebra o fluxo, apenas segue
@@ -265,6 +270,7 @@ class DuokeBot:
         page = self.current_page
         if not page:
             raise RuntimeError("Nenhuma página ativa para submeter o 2FA.")
+        nav_timeout = getattr(settings, "nav_timeout_ms", 60000)
 
         fr_code, sel_code = await self._detect_2fa_input(page)
         if not (fr_code and sel_code):
@@ -283,7 +289,7 @@ class DuokeBot:
                 pass
 
         try:
-            await page.wait_for_load_state("networkidle", timeout=30000)
+            await page.wait_for_load_state("networkidle", timeout=nav_timeout)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- allow navigation timeout to be configured via `NAV_TIMEOUT_MS`
- use new timeout for Duoke login and 2FA flows

## Testing
- `python -m py_compile src/config.py src/duoke.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a34f09f3c0832a88f10bed66ba4c2b