### PR TITLE
fix: bypass HTTPS errors for Duoke login

### DIFF
--- a/src/duoke.py
+++ b/src/duoke.py
@@ -53,6 +53,7 @@ class DuokeBot:
         ctx = await p.chromium.launch_persistent_context(
             user_data_dir=str(user_data_dir),
             headless=headless,  # << corrigido: usa variável
+            ignore_https_errors=True,
             args=[
                 "--no-sandbox",
                 "--disable-dev-shm-usage",


### PR DESCRIPTION
## Summary
- allow Playwright to ignore HTTPS certificate errors when launching the persistent Chromium context

## Testing
- `python -m src.run_once` *(fails: Credenciais Duoke ausentes. Defina DUOKE_EMAIL e DUOKE_PASSWORD (ou settings.duoke_email/duoke_password).)*

------
https://chatgpt.com/codex/tasks/task_e_68a4561a4478832abc742996531cf543