### PR TITLE
fix: correct uvicorn start command

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,6 +4,7 @@ services:
     env: docker
     plan: free
     autoDeploy: true
+    startCommand: uvicorn app_ui:app --host 0.0.0.0 --port $PORT
     healthCheckPath: /
     envVars:
       - key: PYTHONUNBUFFERED


### PR DESCRIPTION
## Summary
- add start command using lowercase `uvicorn` for render deployment

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v Dockerfile.py)`

------
https://chatgpt.com/codex/tasks/task_e_68a458beba2c832a8ee2012bc96e7cd0