### PR TITLE
Add health check endpoint

### DIFF
--- a/app_ui.py
+++ b/app_ui.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Optional, Set
 from collections import deque
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Request, Form, HTTPException
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Request, Form, HTTPException, Response
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Template
@@ -302,6 +302,18 @@ document.getElementById('btnDuokeDisconnect').addEventListener('click', async ()
 """)
 
 app = FastAPI()
+
+
+@app.head("/")
+async def root_head() -> Response:
+    """Simple HEAD handler for platform health checks."""
+    return Response(status_code=200)
+
+
+@app.get("/healthz")
+async def health_check() -> dict:
+    """Health check endpoint used by deployment platforms."""
+    return {"status": "ok"}
 
 # Monta /static somente se a pasta existir (evita erro em ambientes sem assets)
 static_dir = Path("static")


### PR DESCRIPTION
## Summary
- add simple `/healthz` endpoint and HEAD handler to improve platform monitoring

## Testing
- `python -m py_compile app_ui.py`
- `pytest`
- `python - <<'PY'
from fastapi.testclient import TestClient
import app_ui
client = TestClient(app_ui.app)
print('healthz', client.get('/healthz').status_code, client.get('/healthz').json())
print('head_root', client.head('/').status_code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a460d6c580832aa518b3da4775e9aa