### PR TITLE
feat: prompt manual login when session missing

### DIFF
--- a/src/duoke.py
+++ b/src/duoke.py
@@ -205,7 +205,8 @@ class DuokeBot:
         email, password = self._get_creds()
         if not email or not password:
             raise RuntimeError(
-                "Credenciais Duoke ausentes. Defina DUOKE_EMAIL e DUOKE_PASSWORD (ou settings.duoke_email/duoke_password)."
+                "Credenciais Duoke ausentes. Defina DUOKE_EMAIL e DUOKE_PASSWORD (ou settings.duoke_email/duoke_password). "
+                "Como alternativa, faça login manual executando `python -m src.login` antes de iniciar o bot."
             )
 
         # Preenche e tenta logar

--- a/src/login.py
+++ b/src/login.py
@@ -4,7 +4,9 @@ from pathlib import Path
 from playwright.async_api import async_playwright
 from .config import settings
 
-PROFILE_DIR = Path(__file__).resolve().parents[1] / ".playwright_profile"
+# Usa o mesmo diretório de perfil que o bot principal para que o login
+# manual possa ser reutilizado pelas execuções automatizadas.
+PROFILE_DIR = Path(__file__).resolve().parents[1] / "pw-user-data"
 STATE_FILE = Path(__file__).resolve().parents[1] / "storage_state.json"
 
 async def main():

--- a/src/run_loop.py
+++ b/src/run_loop.py
@@ -1,10 +1,12 @@
 # src/run_loop.py
 import os
 import asyncio
+from pathlib import Path
 from .duoke import DuokeBot
 from .classifier import decide_reply
 
 DEFAULT_INTERVAL = float(os.getenv("LOOP_INTERVAL_SECONDS", "5"))
+STATE_FILE = Path(__file__).resolve().parents[1] / "storage_state.json"
 
 async def run_forever(interval: float = DEFAULT_INTERVAL) -> None:
     """
@@ -37,6 +39,9 @@ async def run_forever(interval: float = DEFAULT_INTERVAL) -> None:
             backoff = min(wait * 2, 60.0)
 
 async def main() -> None:
+    if not STATE_FILE.exists():
+        print("[LOOP] Sessão não encontrada. Execute `python -m src.login` para fazer login antes de iniciar o bot.")
+        return
     await run_forever()
 
 if __name__ == "__main__":

--- a/src/run_once.py
+++ b/src/run_once.py
@@ -1,9 +1,15 @@
 # src/run_once.py
 import asyncio
+from pathlib import Path
 from .duoke import DuokeBot
 from .classifier import decide_reply
 
+STATE_FILE = Path(__file__).resolve().parents[1] / "storage_state.json"
+
 async def main():
+    if not STATE_FILE.exists():
+        print("[RUN_ONCE] Sessão não encontrada. Execute `python -m src.login` para fazer login antes de iniciar o bot.")
+        return
     bot = DuokeBot()
 
     # Função síncrona (NÃO async) para evitar "coroutine was never awaited"


### PR DESCRIPTION
## Summary
- reuse bot profile for manual login to persist session
- warn when session file is missing before running the bot
- suggest manual login if credentials are not provided

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a46ac79870832ab5424c701130a11f