### PR TITLE
Increase Playwright page load timeout

### DIFF
--- a/app_ui.py
+++ b/app_ui.py
@@ -432,7 +432,11 @@ async def duoke_connect(email: str = Form(...), password: str = Form(...)):
             ctx = await browser.new_context()
             page = await ctx.new_page()
 
-            await page.goto("https://www.duoke.com/", wait_until="domcontentloaded")
+            await page.goto(
+                "https://www.duoke.com/",
+                wait_until="domcontentloaded",
+                timeout=settings.goto_timeout_ms,
+            )
 
             # Fecha popup "Your login has expired" se aparecer
             try:

--- a/main.py
+++ b/main.py
@@ -13,6 +13,9 @@ from fastapi.responses import HTMLResponse, JSONResponse
 # Importações do Playwright para automatizar o navegador
 from playwright.async_api import async_playwright, TimeoutError as PWTimeoutError
 
+# Configurações compartilhadas
+from src.config import settings
+
 # Importações de Criptografia para garantir a segurança da sessão
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives import hashes
@@ -151,7 +154,11 @@ async def duoke_login_start(
         ctx = await browser.new_context()
         page = await ctx.new_page()
         # Navega para a página de login
-        await page.goto("https://www.duoke.com/", wait_until="domcontentloaded")
+        await page.goto(
+            "https://www.duoke.com/",
+            wait_until="domcontentloaded",
+            timeout=settings.goto_timeout_ms,
+        )
 
         # Tenta fechar o modal "Your login has expired..." ou similar, se aparecer
         try:

--- a/src/config.py
+++ b/src/config.py
@@ -13,5 +13,6 @@ class Settings(BaseModel):
     loop_interval: int = int(os.getenv("LOOP_INTERVAL", "30"))
     delay_after_nav: float = float(os.getenv("DELAY_AFTER_NAV", "1"))
     delay_between_actions: float = float(os.getenv("DELAY_BETWEEN_ACTIONS", "0.1"))
+    goto_timeout_ms: int = int(os.getenv("GOTO_TIMEOUT_MS", "60000"))
 
 settings = Settings()

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -171,7 +171,11 @@ class DuokeBot:
         tenta detectar 2FA. Se 2FA for solicitado, deixa self.awaiting_2fa=True
         e retorna (sem levantar exceção) — a UI deve chamar provide_2fa_code().
         """
-        await page.goto(settings.douke_url, wait_until="domcontentloaded")
+        await page.goto(
+            settings.douke_url,
+            wait_until="domcontentloaded",
+            timeout=settings.goto_timeout_ms,
+        )
 
         # Aguarda rede “assentar”
         try:

--- a/src/login.py
+++ b/src/login.py
@@ -18,7 +18,7 @@ async def main():
             headless=False,
         )
         page = await ctx.new_page()
-        await page.goto(settings.douke_url)
+        await page.goto(settings.douke_url, timeout=settings.goto_timeout_ms)
         print(">>> Faça login no Douke no navegador aberto.")
         input(">>> Quando terminar o login e enxergar suas conversas, pressione Enter aqui... ")
         # Exporta a sessão para storage_state.json (vamos usar isso nos runs)


### PR DESCRIPTION
## Summary
- allow customizing Playwright navigation timeout via new `goto_timeout_ms` setting
- apply the longer timeout when loading Douke in login and server flows

## Testing
- `python -m py_compile src/config.py src/login.py src/duoke.py app_ui.py main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a46e2bb438832ab538f4fc41576c98