### PR TITLE
Add UI controls for manual login handling

### DIFF
--- a/config/selectors.json
+++ b/config/selectors.json
@@ -7,7 +7,12 @@
 
   "message_text": "ul.message_main .msg_text .text_cont, ul.message_main .text_cont, ul.message_main .bubble .text, ul.message_main .record_item .content",
 
-  "input_textarea": ".chat_footer textarea.el-textarea__inner, .input_wrap textarea.el-textarea__inner, textarea.el-textarea__inner",
+  "input_textarea": "textarea, [contenteditable='true']",
+
+  "modal_confirm_button": ".el-dialog__footer .el-button--primary, button:has-text('Confirm'), button:has-text('OK'), .el-message-box__btns .el-button--primary",
+
+  "verify_code_input": "input[placeholder*='code' i], input[aria-label*='code' i], input[name*='code' i]",
+  "verify_submit": "button:has-text('Verify'), button:has-text('Confirm'), .el-button--primary",
 
   "send_button": "button:has-text('Send'), button:has-text('Enviar')",
 


### PR DESCRIPTION
## Summary
- Add selectors for modal confirmation and verification code inputs
- Provide DuokeBot helpers for closing modals and submitting verification codes
- Expose UI controls and FastAPI endpoints to manually close login modal and send verification codes

## Testing
- `python -m py_compile src/duoke.py app_ui.py && echo 'py_compile ok'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4774f6068832aad0cbf4d05822d3c