### PR TITLE
Handle hidden modal confirm button

### DIFF
--- a/config/selectors.json
+++ b/config/selectors.json
@@ -9,7 +9,7 @@
 
   "input_textarea": "textarea, [contenteditable='true']",
 
-  "modal_confirm_button": ".el-dialog__footer .el-button--primary, button:has-text('Confirm'), button:has-text('OK'), .el-message-box__btns .el-button--primary",
+  "modal_confirm_button": ".el-message-box__btns .el-button, .el-dialog__footer .el-button--primary, button:has-text('Confirm'), button:has-text('OK')",
 
   "verify_code_input": "input[placeholder*='code' i], input[aria-label*='code' i], input[name*='code' i]",
   "verify_submit": "button:has-text('Verify'), button:has-text('Confirm'), .el-button--primary",

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -541,10 +541,10 @@ class DuokeBot:
             sel = SEL.get("modal_confirm_button") or ""
             if not sel:
                 # fallback por texto
-                btn = page.get_by_role("button", name=re.compile(r"^(OK|Confirm|Fechar|Entendi)$", re.I))
+                btn = page.get_by_role("button", name=re.compile(r"^(OK|Confirm|Confirmar|Fechar|Entendi)$", re.I))
                 await btn.first.click(timeout=3000)
                 return True
-            btn = page.locator(sel)
+            btn = page.locator(sel).locator(":visible")
             if await btn.count() > 0:
                 await btn.first.click(timeout=3000)
                 await page.wait_for_timeout(500)


### PR DESCRIPTION
## Summary
- Broaden modal confirm selector to capture default buttons and prioritize message box buttons
- Ensure only visible confirm buttons are clicked and add Portuguese fallback text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a47ae68714832a82cf5edbc91596b4