### PR TITLE
Ensure session-expired modal closes correctly

### DIFF
--- a/config/selectors.json
+++ b/config/selectors.json
@@ -9,7 +9,7 @@
 
   "input_textarea": "textarea, [contenteditable='true']",
 
-  "modal_confirm_button": ".el-dialog__footer .el-button--primary, button:has-text('Confirm'), button:has-text('OK'), .el-message-box__btns .el-button--primary",
+  "modal_confirm_button": ".el-dialog__footer .el-button--primary, .el-message-box__btns .el-button, button:has-text('Confirm'), button:has-text('Confirmar'), button:has-text('OK'), button:has-text('Fechar')",
 
   "verify_code_input": "input[placeholder*='code' i], input[aria-label*='code' i], input[name*='code' i]",
   "verify_submit": "button:has-text('Verify'), button:has-text('Confirm'), .el-button--primary",

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -16,7 +16,7 @@ SEL = json.loads(
     .read_text(encoding="utf-8")
 )
 
-CONFIRM_RE = re.compile(r"(confirm|ok|continue|verify|submit|login|entrar|确认|確定|确定)", re.I)
+CONFIRM_RE = re.compile(r"(confirm|confirmar|ok|continue|verify|submit|login|entrar|fechar|entendi|确认|確定|确定)", re.I)
 
 def _env_or_settings(name_env: str, name_settings: str, default: str = "") -> str:
     v = os.getenv(name_env)
@@ -541,7 +541,7 @@ class DuokeBot:
             sel = SEL.get("modal_confirm_button") or ""
             if not sel:
                 # fallback por texto
-                btn = page.get_by_role("button", name=re.compile(r"^(OK|Confirm|Fechar|Entendi)$", re.I))
+                btn = page.get_by_role("button", name=CONFIRM_RE)
                 await btn.first.click(timeout=3000)
                 return True
             btn = page.locator(sel)


### PR DESCRIPTION
## Summary
- broaden modal confirmation selector to catch default/Portuguese buttons
- expand confirmation regex to match more button texts

## Testing
- `pytest`
- `python -m py_compile src/duoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68a47c9a5b78832a8409645536547fe0