### PR TITLE
Handle Confirmar modal button

### DIFF
--- a/config/selectors.json
+++ b/config/selectors.json
@@ -9,7 +9,7 @@
 
   "input_textarea": "textarea, [contenteditable='true']",
 
-  "modal_confirm_button": ".el-dialog__footer .el-button--primary, button:has-text('Confirm'), button:has-text('OK'), .el-message-box__btns .el-button--primary",
+  "modal_confirm_button": ".el-dialog__footer .el-button--primary, button:has-text('Confirm'), button:has-text('Confirmar'), button:has-text('OK'), .el-message-box__btns .el-button--primary, .el-message-box__btns .el-button:has-text('Confirmar')",
 
   "verify_code_input": "input[placeholder*='code' i], input[aria-label*='code' i], input[name*='code' i]",
   "verify_submit": "button:has-text('Verify'), button:has-text('Confirm'), .el-button--primary",

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -541,7 +541,10 @@ class DuokeBot:
             sel = SEL.get("modal_confirm_button") or ""
             if not sel:
                 # fallback por texto
-                btn = page.get_by_role("button", name=re.compile(r"^(OK|Confirm|Fechar|Entendi)$", re.I))
+                btn = page.get_by_role(
+                    "button",
+                    name=re.compile(r"^(OK|Confirm|Confirmar|Fechar|Entendi)$", re.I),
+                )
                 await btn.first.click(timeout=3000)
                 return True
             btn = page.locator(sel)


### PR DESCRIPTION
## Summary
- broaden modal button selector to match 'Confirmar' messages
- support 'Confirmar' in fallback modal closing logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a47c9a5b78832a8409645536547fe0