### PR TITLE
feat: close Element UI modals across frames

### DIFF
--- a/src/login.py
+++ b/src/login.py
@@ -22,7 +22,7 @@ async def main():
         await page.goto(settings.douke_url, timeout=settings.goto_timeout_ms)
         # Fecha automaticamente modal de sessão expirada (botão "Confirmar")
         try:
-            await DuokeBot()._try_close_modal(page)
+            await DuokeBot().close_modal(page)
         except Exception:
             pass
         print(">>> Faça login no Douke no navegador aberto.")


### PR DESCRIPTION
## Summary
- improve modal closing helper to search page and iframes, trying role/name, CSS and JS fallbacks, pressing Enter as last resort, and waiting for modal to disappear
- expand confirmation regex with more languages and log results
- use new helper in manual login script

## Testing
- `python -m py_compile src/duoke.py src/login.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a47f66d904832a83de7289d5ad3111