### PR TITLE
Handle Duoke login button and add code field

### DIFF
--- a/src/duoke.py
+++ b/src/duoke.py
@@ -18,7 +18,7 @@ SEL = json.loads(
 
 # Botões de confirmação comuns em modais (várias línguas)
 CONFIRM_RE = re.compile(
-    r"(confirm|confirmar|ok|continue|verify|submit|login|entrar|fechar|确认|確定|确定)",
+    r"(confirm|confirmar|ok|continue|verify|submit|login|entrar|fechar|iniciar\s*sess[aã]o|确认|確定|确定)",
     re.I,
 )
 
@@ -260,7 +260,7 @@ class DuokeBot:
 
         # Clica Login (vários nomes)
         try:
-            await fr.get_by_role("button", name=re.compile(r"(login|entrar|sign\s*in|提交|登录)", re.I)).click(timeout=2500)
+            await fr.get_by_role("button", name=re.compile(r"(login|entrar|sign\s*in|iniciar\s*sess[aã]o|提交|登录)", re.I)).click(timeout=2500)
         except PWTimeoutError:
             # fallback: primeiro botão visível
             try:


### PR DESCRIPTION
## Summary
- Stack Duoke login fields vertically and include optional verification code input
- Teach automated login to recognize "Iniciar sessão" buttons
- Allow backend login endpoint to send optional code before clicking the updated button

## Testing
- `python -m py_compile app_ui.py src/duoke.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48656876c832ab4ec80ba82e2633e